### PR TITLE
Implemented a settings reader API for hanzo.

### DIFF
--- a/src/hanzo/pyproject.py
+++ b/src/hanzo/pyproject.py
@@ -1,7 +1,7 @@
 import functools
 import tomllib
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, Any
 
 from packaging.utils import NormalizedName, canonicalize_name
 from packaging.version import Version
@@ -13,15 +13,25 @@ class ProjectSettings(TypedDict):
 
 
 @functools.lru_cache(maxsize=1)
-def parse_project_settings() -> ProjectSettings:
+def parse_pyproject() -> dict[str, Any]:
     # in a wheel build, cwd is the project root.
     pyproject_path = Path("pyproject.toml")
     with open(pyproject_path, "rb") as pyproj:
         pyproject = tomllib.load(pyproj)
+    return pyproject
 
+
+def parse_project_settings() -> ProjectSettings:
+    pyproject = parse_pyproject()
     project_info = pyproject["project"]
     project_settings: ProjectSettings = {
         "name": canonicalize_name(project_info["name"], validate=True),
         "version": Version(project_info["version"]),
     }
     return project_settings
+
+def parse_hanzo_settings() -> dict[str, Any]:
+    pyproject = parse_pyproject()
+    hanzo_info = pyproject.get("tool", {}).get("hanzo", {})
+    return hanzo_info
+


### PR DESCRIPTION
Implemented a settings reader API for hanzo. should take pyproject.toml as input,  and return a dict of settings.