### PR TITLE
wheel writer: Add support for nuanced gitignore writing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,14 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = [
-    "pyrefly>=0.55.0",
-    "ruff>=0.15.2",
-]
 tests = [
     "build>=1.4.0",
     "pytest>=9.0.2",
+]
+zed = [
+    "pyrefly>=0.60.0",
+    "ruff>=0.15.2",
+    "ty>=0.0.29",
 ]
 
 [tool.ruff]

--- a/src/hanzo/__init__.py
+++ b/src/hanzo/__init__.py
@@ -13,7 +13,7 @@ from hanzo.settings import (
     parse_project_metadata,
 )
 from hanzo.targets import CCExtensionTarget, CCLibraryTarget
-from hanzo.utils import calculate_wheel_tag, to_snakecase
+from hanzo.utils import calculate_wheel_tag, collect_src_files, to_snakecase
 from hanzo.wheelfile import WheelWriter
 
 __version__ = "0.1.0"
@@ -107,10 +107,11 @@ def build_wheel(
         # TODO: Move into prepare_metadata
         wheel.write_metadata(metadata)
 
-        # TODO: Create a more comprehensive wheel inclusion list with .gitignore and others.
-        for dirpath, dirnames, files in os.walk("src"):
-            for f in files:
-                wheel.write_file(project_path / f, Path(dirpath) / f, timestamp=datetime.now())
+        for archive_path, disk_path in collect_src_files(Path("src")):
+            if Path(archive_path).suffix in settings.wheel.sources:
+                wheel.write_file(archive_path, disk_path, timestamp=datetime.now())
+            else:
+                wheel.write_data_file(str(archive_path), disk_path, timestamp=datetime.now())
 
         for file in build_dir.iterdir():
             # TODO: Refine this based on the expected kinds of build artifacts,

--- a/src/hanzo/constants.py
+++ b/src/hanzo/constants.py
@@ -6,3 +6,6 @@ DEFAULT_PY_TOOLCHAIN_NAME: str = "current"
 
 # default build directory for C/C++ extensions
 DEFAULT_BUILD_DIR = "build"
+
+# default source file extensions
+DEFAULT_SOURCE_EXTENSIONS: frozenset[str] = frozenset({".py", ".cpp", ".c", ".h", ".hpp", ".pyi"})

--- a/src/hanzo/ninja.py
+++ b/src/hanzo/ninja.py
@@ -27,10 +27,8 @@ import sysconfig
 import textwrap
 from io import TextIOWrapper
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from hanzo.rules import Rule
+from hanzo.rules import Rule
 
 
 def get_ninja_executable() -> str:

--- a/src/hanzo/settings.py
+++ b/src/hanzo/settings.py
@@ -12,6 +12,7 @@ from hanzo.constants import (
     DEFAULT_BUILD_DIR,
     DEFAULT_CC_TOOLCHAIN_NAME,
     DEFAULT_PY_TOOLCHAIN_NAME,
+    DEFAULT_SOURCE_EXTENSIONS,
     METADATA_VERSION,
 )
 from hanzo.features import Feature, get_feature
@@ -62,6 +63,11 @@ class SdistSettings:
 @dataclass
 class WheelSettings:
     stable_abi: str | None = None
+    sources: frozenset[str] = field(default_factory=lambda: DEFAULT_SOURCE_EXTENSIONS)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.sources, frozenset):
+            self.sources = frozenset(self.sources)
 
 
 @dataclass

--- a/src/hanzo/utils.py
+++ b/src/hanzo/utils.py
@@ -1,14 +1,101 @@
 from __future__ import annotations
 
 import dataclasses
+import fnmatch
+import os
 import sysconfig
-from typing import TYPE_CHECKING
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
 
 from packaging.specifiers import SpecifierSet
 from packaging.tags import Tag
 
 if TYPE_CHECKING:
     from hanzo.settings import BuildConfig, HanzoSettings
+
+
+class GitignorePattern(NamedTuple):
+    pattern: str
+    negated: bool
+
+
+def _load_gitignore_patterns(root: Path) -> list[GitignorePattern]:
+    """Read .gitignore from root and return a list of GitignorePattern entries."""
+    gitignore = root / ".gitignore"
+    if not gitignore.exists():
+        return []
+    patterns: list[GitignorePattern] = []
+    for line in gitignore.read_text(encoding="utf-8").splitlines():
+        line = line.rstrip()
+        if not line or line.startswith("#"):
+            continue
+        negated = line.startswith("!")
+        if negated:
+            line = line[1:]
+        patterns.append(GitignorePattern(line, negated))
+    return patterns
+
+
+def _gitignore_matches(posix_path: str, pattern: str, *, is_dir: bool = False) -> bool:
+    """Return True if posix_path matches the given gitignore pattern."""
+    dir_only = pattern.endswith("/")
+    if dir_only:
+        if not is_dir:
+            return False
+        pattern = pattern[:-1]
+
+    if not pattern:
+        return False
+
+    # No slash in pattern: match against basename only (any depth)
+    if "/" not in pattern.lstrip("/"):
+        name = posix_path.rsplit("/", 1)[-1] if "/" in posix_path else posix_path
+        return fnmatch.fnmatch(name, pattern)
+
+    # Pattern with slash: match against the full path from root
+    pat = pattern.lstrip("/")
+    return fnmatch.fnmatch(posix_path, pat) or fnmatch.fnmatch(posix_path, "*/" + pat)
+
+
+def _is_gitignored(
+    posix_path: str, patterns: list[GitignorePattern], *, is_dir: bool = False
+) -> bool:
+    """Return True if posix_path is excluded by the given gitignore patterns."""
+    ignored = False
+    for entry in patterns:
+        if _gitignore_matches(posix_path, entry.pattern, is_dir=is_dir):
+            ignored = not entry.negated
+    return ignored
+
+
+def collect_src_files(src_dir: Path) -> Iterator[tuple[Path, Path]]:
+    """Yield ``(archive_path, disk_path)`` for all non-gitignored files under src_dir.
+
+    ``archive_path`` is relative to src_dir (e.g. ``hello/__init__.py``).
+    ``disk_path`` is the absolute path on disk.
+
+    .gitignore patterns are loaded from the current working directory.
+    """
+    cwd = Path.cwd()
+    src_dir = src_dir if src_dir.is_absolute() else cwd / src_dir
+    patterns = _load_gitignore_patterns(cwd)
+
+    for dirpath_str, dirnames, filenames in os.walk(src_dir):
+        dirpath = Path(dirpath_str)
+        rel_dir = dirpath.relative_to(cwd)
+
+        # Prune ignored directories in-place so os.walk skips their subtrees
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if not _is_gitignored((rel_dir / d).as_posix(), patterns, is_dir=True)
+        ]
+
+        for fname in filenames:
+            rel_file = rel_dir / fname
+            if not _is_gitignored(rel_file.as_posix(), patterns):
+                yield dirpath.relative_to(src_dir) / fname, dirpath / fname
 
 
 def to_snakecase(s: str) -> str:
@@ -62,4 +149,10 @@ def guess_minimum_macver(settings: HanzoSettings, arch: str) -> str:
     return "10.13"
 
 
-__all__ = ["calculate_wheel_tag", "guess_minimum_macver", "to_snakecase"]
+__all__ = [
+    "GitignorePattern",
+    "calculate_wheel_tag",
+    "collect_src_files",
+    "guess_minimum_macver",
+    "to_snakecase",
+]

--- a/tests/projects/hello_cc/pyproject.toml
+++ b/tests/projects/hello_cc/pyproject.toml
@@ -14,6 +14,8 @@ hanzo = { path = "../../..", editable = true }
 [tool.hanzo]
 wheel.stable-abi = ">=3.12"
 
+cc.export_compile_commands = true
+
 [tool.hanzo.targets.nanobind]
 type = "cc-library"
 rootpath = "@python.site/nanobind"

--- a/uv.lock
+++ b/uv.lock
@@ -36,13 +36,14 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
-dev = [
-    { name = "pyrefly" },
-    { name = "ruff" },
-]
 tests = [
     { name = "build" },
     { name = "pytest" },
+]
+zed = [
+    { name = "pyrefly" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -53,13 +54,14 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "pyrefly", specifier = ">=0.55.0" },
-    { name = "ruff", specifier = ">=0.15.2" },
-]
 tests = [
     { name = "build", specifier = ">=1.4.0" },
     { name = "pytest", specifier = ">=9.0.2" },
+]
+zed = [
+    { name = "pyrefly", specifier = ">=0.60.0" },
+    { name = "ruff", specifier = ">=0.15.2" },
+    { name = "ty", specifier = ">=0.0.29" },
 ]
 
 [[package]]
@@ -147,18 +149,19 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "0.55.0"
+version = "0.60.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c4/76e0797215e62d007f81f86c9c4fb5d6202685a3f5e70810f3fd94294f92/pyrefly-0.55.0.tar.gz", hash = "sha256:434c3282532dd4525c4840f2040ed0eb79b0ec8224fe18d957956b15471f2441", size = 5135682, upload-time = "2026-03-03T00:46:38.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/c7/28d14b64888e2d03815627ebff8d57a9f08389c4bbebfe70ae1ed98a1267/pyrefly-0.60.0.tar.gz", hash = "sha256:2499f5b6ff5342e86dfe1cd94bcce133519bbbc93b7ad5636195fea4f0fa3b81", size = 5500389, upload-time = "2026-04-06T19:57:30.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/b0/16e50cf716784513648e23e726a24f71f9544aa4f86103032dcaa5ff71a2/pyrefly-0.55.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:49aafcefe5e2dd4256147db93e5b0ada42bff7d9a60db70e03d1f7055338eec9", size = 12210073, upload-time = "2026-03-03T00:46:15.51Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ad/89500c01bac3083383011600370289fbc67700c5be46e781787392628a3a/pyrefly-0.55.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2827426e6b28397c13badb93c0ede0fb0f48046a7a89e3d774cda04e8e2067cd", size = 11767474, upload-time = "2026-03-03T00:46:18.003Z" },
-    { url = "https://files.pythonhosted.org/packages/78/68/4c66b260f817f304ead11176ff13985625f7c269e653304b4bdb546551af/pyrefly-0.55.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7346b2d64dc575bd61aa3bca854fbf8b5a19a471cbdb45e0ca1e09861b63488c", size = 33260395, upload-time = "2026-03-03T00:46:20.509Z" },
-    { url = "https://files.pythonhosted.org/packages/47/09/10bd48c9f860064f29f412954126a827d60f6451512224912c265e26bbe6/pyrefly-0.55.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:233b861b4cff008b1aff62f4f941577ed752e4d0060834229eb9b6826e6973c9", size = 35848269, upload-time = "2026-03-03T00:46:23.418Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/39/bc65cdd5243eb2dfea25dd1321f9a5a93e8d9c3a308501c4c6c05d011585/pyrefly-0.55.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5aa85657d76da1d25d081a49f0e33c8fc3ec91c1a0f185a8ed393a5a3d9e178", size = 38449820, upload-time = "2026-03-03T00:46:26.309Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/64/58b38963b011af91209e87f868cc85cfc762ec49a4568ce610c45e7a5f40/pyrefly-0.55.0-py3-none-win32.whl", hash = "sha256:23f786a78536a56fed331b245b7d10ec8945bebee7b723491c8d66fdbc155fe6", size = 11259415, upload-time = "2026-03-03T00:46:30.875Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/0b/a4aa519ff632a1ea69eec942566951670b870b99b5c08407e1387b85b6a4/pyrefly-0.55.0-py3-none-win_amd64.whl", hash = "sha256:d465b49e999b50eeb069ad23f0f5710651cad2576f9452a82991bef557df91ee", size = 12043581, upload-time = "2026-03-03T00:46:33.674Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/51/89017636fbe1ffd166ad478990c6052df615b926182fa6d3c0842b407e89/pyrefly-0.55.0-py3-none-win_arm64.whl", hash = "sha256:732ff490e0e863b296e7c0b2471e08f8ba7952f9fa6e9de09d8347fd67dde77f", size = 11548076, upload-time = "2026-03-03T00:46:36.193Z" },
+    { url = "https://files.pythonhosted.org/packages/31/99/6c9984a09220e5eb7dd5c869b7a32d25c3d06b5e8854c6eb679db1145c3e/pyrefly-0.60.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bf1691af0fee69d0c99c3c6e9d26ab6acd3c8afef96416f9ba2e74934833b7b5", size = 12921262, upload-time = "2026-04-06T19:57:00.745Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b3/6216aa3c00c88e59a27eb4149851b5affe86eeea6129f4224034a32dddb0/pyrefly-0.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3e71b70c9b95545cf3b479bc55d1381b531de7b2380eb64411088a1e56b634cb", size = 12424413, upload-time = "2026-04-06T19:57:03.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/87/eb8dd73abd92a93952ac27a605e463c432fb250fb23186574038c7035594/pyrefly-0.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:680ee5f8f98230ea145652d7344708f5375786209c5bf03d8b911fdb0d0d4195", size = 35940884, upload-time = "2026-04-06T19:57:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/34/dc6aeb67b840c745fcee6db358295d554abe6ab555a7eaaf44624bd80bf1/pyrefly-0.60.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0d0b20dbbe4aff15b959e8d825b7521a144c4122c11e57022e83b36568c54470", size = 38677220, upload-time = "2026-04-06T19:57:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/66/6b/c863fcf7ef592b7d1db91502acf0d1113be8bed7a2a7143fc6f0dd90616f/pyrefly-0.60.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2911563c8e6b2eaefff68885c94727965469a35375a409235a7a4d2b7157dc15", size = 36907431, upload-time = "2026-04-06T19:57:15.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/25ea095ab2ecca8e62884669b11a79f14299db93071685b73a97efbaf4f3/pyrefly-0.60.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0a631d9d04705e303fe156f2e62551611bc7ef8066c34708ceebcfb3088bd55", size = 41447898, upload-time = "2026-04-06T19:57:19.382Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/2c/097bdc6e8d40676b28eb03710a4577bc3c7b803cd24693ac02bf15de3d67/pyrefly-0.60.0-py3-none-win32.whl", hash = "sha256:a08d69298da5626cf502d3debbb6944fd13d2f405ea6625363751f1ff570d366", size = 11913434, upload-time = "2026-04-06T19:57:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d4/8d27fe310e830c8d11ab73db38b93f9fd2e218744b6efb1204401c9a74d5/pyrefly-0.60.0-py3-none-win_amd64.whl", hash = "sha256:56cf30654e708ae1dd635ffefcba4fa4b349dd7004a6ccc5c41e3a9bb944320c", size = 12745033, upload-time = "2026-04-06T19:57:25.517Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ad/8eea1f8fb8209f91f6dbfe48000c9d05fd0cdb1b5b3157283c9b1dada55d/pyrefly-0.60.0-py3-none-win_arm64.whl", hash = "sha256:b6d27fba970f4777063c0227c54167d83bece1804ea34f69e7118e409ba038d2", size = 12246390, upload-time = "2026-04-06T19:57:28.141Z" },
 ]
 
 [[package]]
@@ -200,4 +203,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
     { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
     { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d5/853561de49fae38c519e905b2d8da9c531219608f1fccc47a0fc2c896980/ty-0.0.29.tar.gz", hash = "sha256:e7936cca2f691eeda631876c92809688dbbab68687c3473f526cd83b6a9228d8", size = 5469221, upload-time = "2026-04-05T15:01:21.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/b7/911f9962115acfa24e3b2ec9d4992dd994c38e8769e1b1d7680bb4d28a51/ty-0.0.29-py3-none-linux_armv6l.whl", hash = "sha256:b8a40955f7660d3eaceb0d964affc81b790c0765e7052921a5f861ff8a471c30", size = 10568206, upload-time = "2026-04-05T15:01:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/fcae2167d4c77a97269f92f11d1b43b03617f81de1283d5d05b43432110c/ty-0.0.29-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6b6849adae15b00bbe2d3c5b078967dcb62eba37d38936b8eeb4c81a82d2e3b8", size = 10442530, upload-time = "2026-04-05T15:01:28.471Z" },
+    { url = "https://files.pythonhosted.org/packages/97/33/5a6bfa240cfcb9c36046ae2459fa9ea23238d20130d8656ff5ac4d6c012a/ty-0.0.29-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dcdd9b17209788152f7b7ea815eda07989152325052fe690013537cc7904ce49", size = 9915735, upload-time = "2026-04-05T15:01:10.365Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/318f45fae232118e81a6306c30f50de42c509c412128d5bd231eab699ffb/ty-0.0.29-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d8ed4789bae78ffaf94462c0d25589a734cab0366b86f2bbcb1bb90e1a7a169", size = 10419748, upload-time = "2026-04-05T15:01:32.375Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a8/5687872e2ab5a0f7dd4fd8456eac31e9381ad4dc74961f6f29965ad4dd91/ty-0.0.29-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91ec374b8565e0ad0900011c24641ebbef2da51adbd4fb69ff3280c8a7eceb02", size = 10394738, upload-time = "2026-04-05T15:01:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/de/68/015d118097eeb95e6a44c4abce4c0a28b7b9dfb3085b7f0ee48e4f099633/ty-0.0.29-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:298a8d5faa2502d3810bbbb47a030b9455495b9921594206043c785dd61548cf", size = 10910613, upload-time = "2026-04-05T15:01:17.17Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/47ce3c6c53e0670eadbe80756b167bf80ed6681d1ba57cfde2e8065a13d1/ty-0.0.29-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c8fba1a3524c6109d1e020d92301c79d41bf442fa8d335b9fa366239339cb70", size = 11475750, upload-time = "2026-04-05T15:01:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cf/e361845b1081c9264ad5b7c963231bab03f2666865a9f2a115c4233f2137/ty-0.0.29-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c48adf88a70d264128c39ee922ed14a947817fced1e93c08c1a89c9244edcde", size = 11190055, upload-time = "2026-04-05T15:01:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/79/12/0fb0857e9a62cb11586e9a712103877bbf717f5fb570d16634408cfdefee/ty-0.0.29-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce0a7a0e96bc7b42518cd3a1a6a6298ef64ff40ca4614355c1aa807059b5c6f", size = 11020539, upload-time = "2026-04-05T15:01:37.022Z" },
+    { url = "https://files.pythonhosted.org/packages/20/36/5a26753802083f80cd125db6c4348ad42b3c982ec36e718e0bf4c18f75e5/ty-0.0.29-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6ac86a05b4a3731d45365ab97780acc7b8146fa62fccb3cbe94fe6546c67a97", size = 10396399, upload-time = "2026-04-05T15:01:26.167Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e6/b4e75b5752239ab3ab400f19faef4dbef81d05aab5d3419fda0c062a3765/ty-0.0.29-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6bbbf53141af0f3150bf288d716263f1a3550054e4b3551ca866d38192ba9891", size = 10421461, upload-time = "2026-04-05T15:01:08.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/21/1084b5b609f9abed62070ec0b31c283a403832a6310c8bbc208bd45ee1e6/ty-0.0.29-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1c9e06b770c1d0ff5efc51e34312390db31d53fcf3088163f413030b42b74f84", size = 10599187, upload-time = "2026-04-05T15:01:23.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a1/ce19a2ca717bbcc1ee11378aba52ef70b6ce5b87245162a729d9fdc2360f/ty-0.0.29-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0307fe37e3f000ef1a4ae230bbaf511508a78d24a5e51b40902a21b09d5e6037", size = 11121198, upload-time = "2026-04-05T15:01:15.22Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6b/f1430b279af704321566ce7ec2725d3d8258c2f815ebd93e474c64cd4543/ty-0.0.29-py3-none-win32.whl", hash = "sha256:7a2a898217960a825f8bc0087e1fdbaf379606175e98f9807187221d53a4a8ed", size = 9995331, upload-time = "2026-04-05T15:01:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ef/3ef01c17785ff9a69378465c7d0faccd48a07b163554db0995e5d65a5a23/ty-0.0.29-py3-none-win_amd64.whl", hash = "sha256:fc1294200226b91615acbf34e0a9ad81caf98c081e9c6a912a31b0a7b603bc3f", size = 11023644, upload-time = "2026-04-05T15:01:04.432Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/55/87280a994d6a2d2647c65e12abbc997ed49835794366153c04c4d9304d76/ty-0.0.29-py3-none-win_arm64.whl", hash = "sha256:f9794bbd1bb3ce13f78c191d0c89ae4c63f52c12b6daa0c6fe220b90d019d12c", size = 10428165, upload-time = "2026-04-05T15:01:34.665Z" },
 ]


### PR DESCRIPTION
Adds functionality to write files in the repo, either as wheel files (based on extensions configured in `wheel.sources`) or data files.

NB: It's probably not necessary to package compiled sources in the wheel if the .so files are present.