### PR TITLE
Add platform-specific flag parsing, unit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
           - "ninja>=1.10.0"
           - "packaging>=26.0"
           - "pyproject-metadata>=0.10.0"
+          - "pytest>=9.0.0"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.8
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ select = ["E", "F", "I", "S", "W", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 "src/hanzo/rules.py" = ["E501"]  # line overruns in rule definitions.
+"tests/**/*.py" = ["S"]  # asserts in test cases.
 
 [tool.pyrefly]
 #### configuring what to type check and where to import from

--- a/src/hanzo/constants.py
+++ b/src/hanzo/constants.py
@@ -8,4 +8,4 @@ DEFAULT_PY_TOOLCHAIN_NAME: str = "current"
 DEFAULT_BUILD_DIR = "build"
 
 # default source file extensions
-DEFAULT_SOURCE_EXTENSIONS: frozenset[str] = frozenset({".py", ".cpp", ".c", ".h", ".hpp", ".pyi"})
+DEFAULT_SOURCE_EXTENSIONS: frozenset[str] = frozenset({".py", ".pyi"})

--- a/src/hanzo/targets.py
+++ b/src/hanzo/targets.py
@@ -25,21 +25,37 @@ class CcRuleTypes(StrEnum):
     ASM = "asm"
 
 
+# Parses a platform key into named groups that mirror the Platform fields.
+# os_version is distinguished from arch by requiring digits at the start.
+_PLATFORM_RE = re.compile(
+    r"(?P<system>[a-z]+)(?:-(?P<os_version>\d[\d.]*))?(?:-(?P<arch>[a-z][a-z0-9_]*))?$",
+    flags=re.IGNORECASE,
+)
+
+
 def _match_platform_dict(
     platform_map: dict[str, list[str]],
     platform: Platform,
 ) -> list:
     """Return the concatenated lists from *platform_map* whose keys match *platform*.
 
-    Each key is treated as a case-insensitive regex matched against
-    ``platform.system``.  For example the key ``"macos"`` matches
-    ``platform.system == "macosx"``.
+    Keys are parsed with ``_PLATFORM_KEY_RE`` into ``system``, ``os_version``,
+    and ``arch`` groups.  The ``system`` group is matched as a case-insensitive
+    regex (e.g. ``"macos"`` matches ``platform.system == "macosx"``).  When an
+    ``arch`` group is captured (e.g. ``"macosx-x86_64"``), the architecture must
+    also match exactly; keys without an arch component match any architecture.
     """
-    system = platform.system.lower()
     result: list = []
     for key, values in platform_map.items():
-        if re.match(key.lower(), system):
-            result.extend(values)
+        m = _PLATFORM_RE.match(key.lower())
+        if m is None:
+            continue
+        if not re.match(m.group("system"), platform.system.lower()):
+            continue
+        key_arch = m.group("arch")
+        if key_arch is not None and key_arch != platform.arch.lower():
+            continue
+        result.extend(values)
     return result
 
 
@@ -111,12 +127,15 @@ class Target:
     def add_feature(self, feature: Feature) -> None: ...
 
     @classmethod
-    def from_toml(cls, toml: dict[str, Any], config: BuildConfig) -> Self: ...
+    def from_toml(cls, toml: dict[str, Any], config: BuildConfig) -> Self:
+        raise NotImplementedError
 
     @property
-    def rules(self) -> Mapping[str, Rule]: ...
+    def rules(self) -> Mapping[str, Rule]:
+        raise NotImplementedError
 
-    def build_outputs(self) -> list[dict]: ...  # TODO: Make this typing more precise
+    def build_outputs(self) -> list[dict]:  # TODO: Make this typing more precise
+        raise NotImplementedError
 
 
 class CCLibraryTarget(Target):

--- a/src/hanzo/targets.py
+++ b/src/hanzo/targets.py
@@ -12,6 +12,7 @@ from types import MappingProxyType
 from typing import Any, Literal, Self, cast
 
 from hanzo.features import CcFeature, Feature
+from hanzo.platform import Platform
 from hanzo.rules import Rule
 from hanzo.settings import BuildConfig
 from hanzo.types import Define, DefineDict, FileGlob, GlobDict, Include, IncludeDict
@@ -22,6 +23,24 @@ class CcRuleTypes(StrEnum):
     LINKSTATIC = "linkstatic"
     LINKSHARED = "linkshared"
     ASM = "asm"
+
+
+def _match_platform_dict(
+    platform_map: dict[str, list[str]],
+    platform: Platform,
+) -> list:
+    """Return the concatenated lists from *platform_map* whose keys match *platform*.
+
+    Each key is treated as a case-insensitive regex matched against
+    ``platform.system``.  For example the key ``"macos"`` matches
+    ``platform.system == "macosx"``.
+    """
+    system = platform.system.lower()
+    result: list = []
+    for key, values in platform_map.items():
+        if re.match(key.lower(), system):
+            result.extend(values)
+    return result
 
 
 def substitute(
@@ -118,11 +137,11 @@ class CCLibraryTarget(Target):
     ):
         super().__init__(name, sources, config, rootpath)
 
-        self.includes = includes or []
-        self.defines = defines or []
-        self.flags = flags or []
-        self.linkflags = linkflags or []
-        self.linkmode = linkmode
+        self.includes: list[Include] = includes or []
+        self.defines: list[Define] = defines or []
+        self.flags: list[str] = flags or []
+        self.linkflags: list[str] = linkflags or []
+        self.linkmode: Literal["static", "shared"] = linkmode
 
         self._libname = libname
 
@@ -147,12 +166,32 @@ class CCLibraryTarget(Target):
 
         parsed_config = toml.copy()
 
-        rootpath: str | os.PathLike[str] = toml.get("rootpath", Path.cwd())
+        name: str = parsed_config.pop("name")
+        sources: list[str | GlobDict] = parsed_config.pop("sources")
+        rootpath: str | os.PathLike[str] = parsed_config.pop("rootpath", Path.cwd())
         rootpath = substitute(rootpath, config)
         raw_includes: list[str | IncludeDict] = toml.get("includes", [])
-        raw_defines: list[str | DefineDict] = toml.get("defines", [])
-        raw_flags: list[str] = toml.get("flags", [])
-        raw_ldflags: list[str] = toml.get("linkflags", [])
+
+        _defines_toml = toml.get("defines", [])
+        raw_defines: list[str | DefineDict] = (
+            _match_platform_dict(_defines_toml, config.platform)
+            if isinstance(_defines_toml, dict)
+            else _defines_toml
+        )
+
+        _flags_toml = toml.get("flags", [])
+        raw_flags: list[str] = (
+            _match_platform_dict(_flags_toml, config.platform)
+            if isinstance(_flags_toml, dict)
+            else _flags_toml
+        )
+
+        _ldflags_toml = toml.get("linkflags", [])
+        raw_ldflags: list[str] = (
+            _match_platform_dict(_ldflags_toml, config.platform)
+            if isinstance(_ldflags_toml, dict)
+            else _ldflags_toml
+        )
         (
             includes,
             defines,
@@ -183,8 +222,7 @@ class CCLibraryTarget(Target):
             linkflags.append(parsed_flag)
 
         parsed_config |= dict(includes=includes, defines=defines, flags=flags, linkflags=linkflags)
-        inst = cls(**parsed_config)
-        return inst
+        return cls(name, sources, config, rootpath, **parsed_config)
 
     def add_dependency(self, dep: Target) -> None:
         # TODO: If unable to restrict typing, go loud and throw errors here.

--- a/tests/unit/test_platform_flags.py
+++ b/tests/unit/test_platform_flags.py
@@ -1,0 +1,78 @@
+"""Tests for platform-keyed flags/linkflags/defines in CCLibraryTarget.from_toml()."""
+
+import tomllib
+from unittest.mock import MagicMock
+
+import pytest
+
+from hanzo.platform import Platform
+from hanzo.targets import CCLibraryTarget
+
+
+@pytest.fixture
+def macos_config():
+    config = MagicMock()
+    config.platform = Platform(system="macosx", os_version="13", arch="arm64")
+    return config
+
+
+@pytest.fixture
+def linux_config():
+    config = MagicMock()
+    config.platform = Platform(system="linux", os_version=None, arch="x86_64")
+    return config
+
+
+PLATFORM_SPECIFIC_TOML = """
+[targets.mylib]
+name = "mylib"
+sources = []
+
+flags.macos = ["-fPIC", "-fvisibility=hidden"]
+flags.linux = ["-fno-pie"]
+
+linkflags.macos = ["-Wl,-dead_strip"]
+linkflags.linux = ["-Wl,--gc-sections"]
+
+defines.macos = ["NDEBUG"]
+defines.linux = ["_GNU_SOURCE"]
+"""
+
+CROSS_PLATFORM_TOML = """
+[targets.mylib]
+name = "mylib"
+sources = []
+
+flags = ["-fPIC", "-Wall"]
+linkflags = ["-Wl,--gc-sections"]
+defines = ["NDEBUG", "MY_DEFINE=1"]
+"""
+
+
+def test_macos_platform_pickups(macos_config):
+    toml = tomllib.loads(PLATFORM_SPECIFIC_TOML)["targets"]["mylib"]
+    target = CCLibraryTarget.from_toml(toml, macos_config)
+    assert target.flags == ["-fPIC", "-fvisibility=hidden"]
+    assert target.linkflags == ["-Wl,-dead_strip"]
+    assert len(target.defines) == 1
+    assert target.defines[0].name == "NDEBUG"
+
+
+def test_linux_platform_pickups(linux_config):
+    toml = tomllib.loads(PLATFORM_SPECIFIC_TOML)["targets"]["mylib"]
+    target = CCLibraryTarget.from_toml(toml, linux_config)
+    assert target.flags == ["-fno-pie"]
+    assert target.linkflags == ["-Wl,--gc-sections"]
+    assert len(target.defines) == 1
+    assert target.defines[0].name == "_GNU_SOURCE"
+
+
+def test_cross_platform_config(linux_config):
+    toml = tomllib.loads(CROSS_PLATFORM_TOML)["targets"]["mylib"]
+    target = CCLibraryTarget.from_toml(toml, linux_config)
+    assert target.flags == ["-fPIC", "-Wall"]
+    assert target.linkflags == ["-Wl,--gc-sections"]
+    assert len(target.defines) == 2
+    assert target.defines[0].name == "NDEBUG"
+    assert target.defines[1].name == "MY_DEFINE"
+    assert target.defines[1].value == "1"

--- a/tests/unit/test_platform_flags.py
+++ b/tests/unit/test_platform_flags.py
@@ -17,6 +17,13 @@ def macos_config():
 
 
 @pytest.fixture
+def macos_x86_config():
+    config = MagicMock()
+    config.platform = Platform(system="macosx", os_version="11", arch="x86_64")
+    return config
+
+
+@pytest.fixture
 def linux_config():
     config = MagicMock()
     config.platform = Platform(system="linux", os_version=None, arch="x86_64")
@@ -36,6 +43,14 @@ linkflags.linux = ["-Wl,--gc-sections"]
 
 defines.macos = ["NDEBUG"]
 defines.linux = ["_GNU_SOURCE"]
+"""
+
+ARCH_SPECIFIC_TOML = """
+[targets.mylib]
+name = "mylib"
+sources = []
+
+flags."macosx-x86_64" = ["-march=native"]
 """
 
 CROSS_PLATFORM_TOML = """
@@ -65,6 +80,21 @@ def test_linux_platform_pickups(linux_config):
     assert target.linkflags == ["-Wl,--gc-sections"]
     assert len(target.defines) == 1
     assert target.defines[0].name == "_GNU_SOURCE"
+
+
+def test_arch_match_pickup(macos_x86_config):
+    """Tests that a platform-specific flag is picked up for the target architecture."""
+    toml = tomllib.loads(ARCH_SPECIFIC_TOML)["targets"]["mylib"]
+    target = CCLibraryTarget.from_toml(toml, macos_x86_config)
+    assert target.flags == ["-march=native"]
+
+
+def test_arch_mismatch_skips_flags(macos_config):
+    """Tests that a flag is skipped for a system match, but architecture mismatch."""
+    # macos_config has arch == "arm64", the key targets x86_64 only, and should be ignored.
+    toml = tomllib.loads(ARCH_SPECIFIC_TOML)["targets"]["mylib"]
+    target = CCLibraryTarget.from_toml(toml, macos_config)
+    assert target.flags == []
 
 
 def test_cross_platform_config(linux_config):


### PR DESCRIPTION
Offers both the per-platform config case (more likely) and the cross-platform case (unlikely). Adds unit tests that cover both cases.