### PR TITLE
ci: Add GitHub actions minimal config

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+name: Python checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Run Python code formatter and type checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - run: uvx pre-commit run --all-files --verbose --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 0.58.0
+    rev: 0.60.0
     hooks:
       - id: pyrefly-check
         name: Pyrefly (type checking)
@@ -20,8 +20,13 @@ repos:
           - "pyproject-metadata>=0.10.0"
           - "pytest>=9.0.0"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.9
     hooks:
       - id: ruff-check
         args: [--fix, --unsafe-fixes, --exit-non-zero-on-fix]
       - id: ruff-format
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.23.1
+    hooks:
+      - id: zizmor
+        args: [--min-severity=medium]

--- a/src/hanzo/__init__.py
+++ b/src/hanzo/__init__.py
@@ -62,7 +62,7 @@ def build_wheel(
             for ext in ext_modules.values():
                 if settings.cc.export_compile_commands:
                     # TODO: Extend to support custom extension types
-                    if isinstance(ext, CCLibraryTarget | CCExtensionTarget):
+                    if isinstance(ext, CCLibraryTarget):
                         cc_compilation_rules.add(ext.rules["cc"])
 
                 for rule in ext.rules.values():


### PR DESCRIPTION
Currently only a pre-commit linting job.

Also adds a zizmor pre-commit hook. Action pins provided by `pinact run -u`.