### PR TITLE
Refactor file matching to GitignoreMatcher class, add tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: Python checks
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 permissions: {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ exclude = ["tests/projects/**"]
 # Enable pycodestyle errors & warnings (`E`, `W`), bandit (`S`), Pyflakes (`F`),
 # isort (`I`), and pyupgrade (`UP`) by default.
 select = ["E", "F", "I", "S", "W", "UP"]
+ignore = ["E203", "E501"]
 
 [tool.ruff.lint.per-file-ignores]
 "src/hanzo/rules.py" = ["E501"]  # line overruns in rule definitions.

--- a/src/hanzo/__init__.py
+++ b/src/hanzo/__init__.py
@@ -13,7 +13,7 @@ from hanzo.settings import (
     parse_project_metadata,
 )
 from hanzo.targets import CCExtensionTarget, CCLibraryTarget
-from hanzo.utils import calculate_wheel_tag, collect_src_files, to_snakecase
+from hanzo.utils import GitignoreMatcher, calculate_wheel_tag, to_snakecase
 from hanzo.wheelfile import WheelWriter
 
 __version__ = "0.1.0"
@@ -107,11 +107,12 @@ def build_wheel(
         # TODO: Move into prepare_metadata
         wheel.write_metadata(metadata)
 
-        for archive_path, disk_path in collect_src_files(Path("src")):
-            if Path(archive_path).suffix in settings.wheel.sources:
-                wheel.write_file(archive_path, disk_path, timestamp=datetime.now())
-            else:
-                wheel.write_data_file(str(archive_path), disk_path, timestamp=datetime.now())
+        matcher = GitignoreMatcher.from_gitignore()
+        for file in matcher.match_files("src"):
+            if file.suffix in settings.wheel.sources:
+                wheel.write_file(project_path / file.name, file, timestamp=datetime.now())
+            elif file.suffix in settings.wheel.data:
+                wheel.write_data_file(str(file), file, timestamp=datetime.now())
 
         for file in build_dir.iterdir():
             # TODO: Refine this based on the expected kinds of build artifacts,

--- a/src/hanzo/constants.py
+++ b/src/hanzo/constants.py
@@ -7,5 +7,6 @@ DEFAULT_PY_TOOLCHAIN_NAME: str = "current"
 # default build directory for C/C++ extensions
 DEFAULT_BUILD_DIR = "build"
 
-# default source file extensions
+# default source and data file extensions
 DEFAULT_SOURCE_EXTENSIONS: frozenset[str] = frozenset({".py", ".pyi"})
+DEFAULT_DATA_EXTENSIONS: frozenset[str] = frozenset()

--- a/src/hanzo/settings.py
+++ b/src/hanzo/settings.py
@@ -64,10 +64,13 @@ class SdistSettings:
 class WheelSettings:
     stable_abi: str | None = None
     sources: frozenset[str] = field(default_factory=lambda: DEFAULT_SOURCE_EXTENSIONS)
+    data: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
         if not isinstance(self.sources, frozenset):
             self.sources = frozenset(self.sources)
+        if not isinstance(self.data, frozenset):
+            self.data = frozenset(self.data)
 
 
 @dataclass
@@ -225,8 +228,6 @@ def load_extensions(config: BuildConfig) -> Mapping[str, "Target"]:
         target_type: str = _struct.pop("type")
         deps: list[str] = _struct.pop("dependencies", [])
         feature_names: list[str] = _struct.pop("features", [])
-        # ... and add config key for interpolating magic values in resources.
-        _struct["config"] = config
 
         target = _BUILTIN_TARGETS[target_type].from_toml(_struct, config)
         for dep in deps:

--- a/src/hanzo/utils.py
+++ b/src/hanzo/utils.py
@@ -79,11 +79,7 @@ class GitignoreMatcher:
             rel_dir = dirpath.relative_to(Path.cwd())
 
             # Prune ignored directories in-place so os.walk skips their subtrees
-            dirnames[:] = [
-                d
-                for d in dirnames
-                if not self.ignored(Path(d).resolve())
-            ]
+            dirnames[:] = [d for d in dirnames if not self.ignored(Path(d).resolve())]
 
             for fname in filenames:
                 rel_file = rel_dir / fname

--- a/src/hanzo/utils.py
+++ b/src/hanzo/utils.py
@@ -4,9 +4,9 @@ import dataclasses
 import fnmatch
 import os
 import sysconfig
-from collections.abc import Iterator
+from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, Self
 
 from packaging.specifiers import SpecifierSet
 from packaging.tags import Tag
@@ -20,82 +20,75 @@ class GitignorePattern(NamedTuple):
     negated: bool
 
 
-def _load_gitignore_patterns(root: Path) -> list[GitignorePattern]:
-    """Read .gitignore from root and return a list of GitignorePattern entries."""
-    gitignore = root / ".gitignore"
-    if not gitignore.exists():
-        return []
-    patterns: list[GitignorePattern] = []
-    for line in gitignore.read_text(encoding="utf-8").splitlines():
-        line = line.rstrip()
-        if not line or line.startswith("#"):
-            continue
-        negated = line.startswith("!")
-        if negated:
-            line = line[1:]
-        patterns.append(GitignorePattern(line, negated))
-    return patterns
+class GitignoreMatcher:
+    def __init__(self, patterns: list[GitignorePattern]):
+        self.patterns: list[GitignorePattern] = patterns
 
+    @classmethod
+    def from_gitignore(cls, path: str | os.PathLike[str] | None = None) -> Self:
+        if path is None:
+            path = Path.cwd()
+        gitignore = Path(path) / ".gitignore"
+        if not gitignore.exists():
+            return cls([])
 
-def _gitignore_matches(posix_path: str, pattern: str, *, is_dir: bool = False) -> bool:
-    """Return True if posix_path matches the given gitignore pattern."""
-    dir_only = pattern.endswith("/")
-    if dir_only:
-        if not is_dir:
+        patterns: list[GitignorePattern] = []
+        for line in gitignore.read_text(encoding="utf-8").splitlines():
+            line = line.rstrip()
+            if not line or line.startswith("#"):
+                continue
+            negated = line.startswith("!")
+            if negated:
+                line = line[1:]
+            patterns.append(GitignorePattern(line, negated))
+        return cls(patterns)
+
+    def ignored(self, path: str | os.PathLike[str]) -> bool:
+        """Check if a path is ignored based on the patterns in this .gitignore file."""
+        if not self.patterns:
             return False
-        pattern = pattern[:-1]
 
-    if not pattern:
-        return False
+        pathlib_path = Path(path)
+        ignored: bool = False
+        for pattern, negated in self.patterns:
+            dir_only = pattern.endswith("/")
+            if dir_only:
+                if not pathlib_path.is_dir():
+                    continue
+                pattern = pattern[:-1]
 
-    # No slash in pattern: match against basename only (any depth)
-    if "/" not in pattern.lstrip("/"):
-        name = posix_path.rsplit("/", 1)[-1] if "/" in posix_path else posix_path
-        return fnmatch.fnmatch(name, pattern)
+            # No slash in pattern: match against basename only (any depth)
+            pat = pattern.lstrip("/")
+            if "/" not in pat:
+                match = fnmatch.fnmatch(pathlib_path.name, pattern)
+            else:
+                # Pattern with slash: match against the full path from root
+                posix_path = pathlib_path.as_posix()
+                match = fnmatch.fnmatch(posix_path, pat) or fnmatch.fnmatch(posix_path, "*/" + pat)
 
-    # Pattern with slash: match against the full path from root
-    pat = pattern.lstrip("/")
-    return fnmatch.fnmatch(posix_path, pat) or fnmatch.fnmatch(posix_path, "*/" + pat)
+            if match:
+                ignored = not negated
 
+        return ignored
 
-def _is_gitignored(
-    posix_path: str, patterns: list[GitignorePattern], *, is_dir: bool = False
-) -> bool:
-    """Return True if posix_path is excluded by the given gitignore patterns."""
-    ignored = False
-    for entry in patterns:
-        if _gitignore_matches(posix_path, entry.pattern, is_dir=is_dir):
-            ignored = not entry.negated
-    return ignored
+    def match_files(self, path: str | os.PathLike[str]) -> Iterable[Path]:
+        path = Path(path).resolve()
 
+        for sdirpath, dirnames, filenames in os.walk(path):
+            dirpath = Path(sdirpath)
+            rel_dir = dirpath.relative_to(Path.cwd())
 
-def collect_src_files(src_dir: Path) -> Iterator[tuple[Path, Path]]:
-    """Yield ``(archive_path, disk_path)`` for all non-gitignored files under src_dir.
+            # Prune ignored directories in-place so os.walk skips their subtrees
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if not self.ignored(Path(d).resolve())
+            ]
 
-    ``archive_path`` is relative to src_dir (e.g. ``hello/__init__.py``).
-    ``disk_path`` is the absolute path on disk.
-
-    .gitignore patterns are loaded from the current working directory.
-    """
-    cwd = Path.cwd()
-    src_dir = src_dir if src_dir.is_absolute() else cwd / src_dir
-    patterns = _load_gitignore_patterns(cwd)
-
-    for dirpath_str, dirnames, filenames in os.walk(src_dir):
-        dirpath = Path(dirpath_str)
-        rel_dir = dirpath.relative_to(cwd)
-
-        # Prune ignored directories in-place so os.walk skips their subtrees
-        dirnames[:] = [
-            d
-            for d in dirnames
-            if not _is_gitignored((rel_dir / d).as_posix(), patterns, is_dir=True)
-        ]
-
-        for fname in filenames:
-            rel_file = rel_dir / fname
-            if not _is_gitignored(rel_file.as_posix(), patterns):
-                yield dirpath.relative_to(src_dir) / fname, dirpath / fname
+            for fname in filenames:
+                rel_file = rel_dir / fname
+                if not self.ignored(rel_file):
+                    yield rel_file
 
 
 def to_snakecase(s: str) -> str:
@@ -150,9 +143,9 @@ def guess_minimum_macver(settings: HanzoSettings, arch: str) -> str:
 
 
 __all__ = [
+    "GitignoreMatcher",
     "GitignorePattern",
     "calculate_wheel_tag",
-    "collect_src_files",
     "guess_minimum_macver",
     "to_snakecase",
 ]

--- a/tests/unit/test_gitignore_matcher.py
+++ b/tests/unit/test_gitignore_matcher.py
@@ -1,6 +1,5 @@
 """Unit tests for the GitignoreMatcher in hanzo.utils, responsible for writing files to the wheel."""
 
-
 from hanzo.utils import GitignoreMatcher, GitignorePattern
 
 

--- a/tests/unit/test_gitignore_matcher.py
+++ b/tests/unit/test_gitignore_matcher.py
@@ -1,0 +1,180 @@
+"""Unit tests for the GitignoreMatcher in hanzo.utils, responsible for writing files to the wheel."""
+
+
+from hanzo.utils import GitignoreMatcher, GitignorePattern
+
+
+def make_matcher(*patterns: str) -> GitignoreMatcher:
+    """Build a GitignoreMatcher from plain pattern strings.
+
+    Prefix a pattern with ``!`` to make it a negation rule, matching the
+    behaviour of ``from_gitignore``.
+    """
+    parsed: list[GitignorePattern] = []
+    for p in patterns:
+        negated = p.startswith("!")
+        parsed.append(GitignorePattern(p[1:] if negated else p, negated))
+    return GitignoreMatcher(parsed)
+
+
+# ---------------------------------------------------------------------------
+# from_gitignore
+# ---------------------------------------------------------------------------
+
+
+def test_from_gitignore_missing_file_returns_empty_matcher(tmp_path):
+    matcher = GitignoreMatcher.from_gitignore(tmp_path)
+    assert matcher.patterns == []
+
+
+def test_from_gitignore_skips_blank_lines_and_comments(tmp_path):
+    (tmp_path / ".gitignore").write_text("# this is a comment\n\n*.pyc\n")
+    matcher = GitignoreMatcher.from_gitignore(tmp_path)
+    assert matcher.patterns == [GitignorePattern("*.pyc", False)]
+
+
+def test_from_gitignore_parses_negation(tmp_path):
+    (tmp_path / ".gitignore").write_text("*.log\n!important.log\n")
+    matcher = GitignoreMatcher.from_gitignore(tmp_path)
+    assert matcher.patterns == [
+        GitignorePattern("*.log", False),
+        GitignorePattern("important.log", True),
+    ]
+
+
+def test_from_gitignore_star_pattern(tmp_path):
+    """Pattern ``*`` (as used in .venv/.gitignore) is parsed as a single pattern."""
+    (tmp_path / ".gitignore").write_text("*\n")
+    matcher = GitignoreMatcher.from_gitignore(tmp_path)
+    assert matcher.patterns == [GitignorePattern("*", False)]
+
+
+# ---------------------------------------------------------------------------
+# ignored(): simple wildcards
+# ---------------------------------------------------------------------------
+
+
+def test_wildcard_matches_by_extension():
+    m = make_matcher("*.pyc")
+    assert m.ignored("foo.pyc")
+    assert not m.ignored("foo.py")
+
+
+def test_wildcard_matches_at_any_depth():
+    m = make_matcher("*.o")
+    assert m.ignored("build/foo/bar.o")
+    assert not m.ignored("build/foo/bar.obj")
+
+
+def test_exact_name_pattern():
+    m = make_matcher(".DS_Store")
+    assert m.ignored(".DS_Store")
+    assert m.ignored("subdir/.DS_Store")
+    assert not m.ignored("DS_Store")
+
+
+# ---------------------------------------------------------------------------
+# ignored(): negation
+# ---------------------------------------------------------------------------
+
+
+def test_negation_re_includes_file():
+    m = make_matcher("*.log", "!important.log")
+    assert m.ignored("debug.log")
+    assert not m.ignored("important.log")
+
+
+def test_negation_order_matters_later_wildcard_wins():
+    # negation first, then wildcard: file ends up ignored
+    m = make_matcher("!important.log", "*.log")
+    assert m.ignored("important.log")
+
+
+# ---------------------------------------------------------------------------
+# ignored(): directory-only patterns (trailing slash)
+# ---------------------------------------------------------------------------
+
+
+def test_directory_only_pattern_ignores_directory(tmp_path):
+    d = tmp_path / "dist"
+    d.mkdir()
+    m = make_matcher("dist/")
+    assert m.ignored(d)
+
+
+def test_directory_only_pattern_does_not_ignore_file(tmp_path):
+    f = tmp_path / "dist"
+    f.write_text("")
+    m = make_matcher("dist/")
+    assert not m.ignored(f)
+
+
+# ---------------------------------------------------------------------------
+# ignored(): slash patterns (path-rooted matching)
+# ---------------------------------------------------------------------------
+
+
+def test_slash_pattern_matches_at_root():
+    m = make_matcher("src/generated")
+    assert m.ignored("src/generated")
+
+
+def test_slash_pattern_matches_relative_subpath():
+    m = make_matcher("src/generated")
+    assert m.ignored("project/src/generated")
+
+
+def test_slash_pattern_does_not_match_different_parent():
+    m = make_matcher("src/generated")
+    assert not m.ignored("lib/generated")
+    assert not m.ignored("generated")
+
+
+# ---------------------------------------------------------------------------
+# ignored(): star pattern (e.g. .venv/.gitignore contains only ``*``)
+# ---------------------------------------------------------------------------
+
+
+def test_star_pattern_ignores_any_name():
+    m = make_matcher("*")
+    assert m.ignored("anything.txt")
+    assert m.ignored("deep/nested/file.py")
+
+
+# ---------------------------------------------------------------------------
+# match_files()
+# ---------------------------------------------------------------------------
+
+
+def test_match_files_excludes_ignored_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gitignore").write_text("*.pyc\n")
+    (tmp_path / "main.py").write_text("")
+    (tmp_path / "main.pyc").write_text("")
+    sub = tmp_path / "pkg"
+    sub.mkdir()
+    (sub / "helper.py").write_text("")
+    (sub / "helper.pyc").write_text("")
+
+    matcher = GitignoreMatcher.from_gitignore(tmp_path)
+    names = {p.name for p in matcher.match_files(tmp_path)}
+
+    assert "main.py" in names
+    assert "helper.py" in names
+    assert "main.pyc" not in names
+    assert "helper.pyc" not in names
+
+
+def test_match_files_prunes_ignored_directories(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gitignore").write_text("build/\n")
+    (tmp_path / "main.py").write_text("")
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "output.o").write_text("")
+
+    matcher = GitignoreMatcher.from_gitignore(tmp_path)
+    names = {p.name for p in matcher.match_files(tmp_path)}
+
+    assert "main.py" in names
+    assert "output.o" not in names


### PR DESCRIPTION
This is a class-based rewrite of the matching functionality that yields files solely based on the gitignore file in the repo root, if there is one. In particular, when building an sdist, where there (presumably) is no gitignore, this contains a fast path that just yields every file for a directory, similarly to os.walk().