### PR TITLE
Add `build_sdist` implementation

### DIFF
--- a/src/hanzo/__init__.py
+++ b/src/hanzo/__init__.py
@@ -1,11 +1,12 @@
 """hanzo is a build backend for modern Python based on ninja."""
 
 import os
+import tarfile
 from datetime import datetime
 from pathlib import Path
 
 import hanzo.ninja as _ninja
-from hanzo.constants import WHEEL_FILENAME
+from hanzo.constants import SDIST_FILENAME, WHEEL_FILENAME
 from hanzo.rules import Rule
 from hanzo.settings import (
     BuildConfig,
@@ -140,7 +141,38 @@ def build_wheel(
 def build_sdist(
     sdist_directory: str | os.PathLike[str],
     config_settings: dict[str, str | list[str]] | None = None,
-) -> str: ...
+) -> str:
+    metadata = parse_project_metadata()
+    settings = parse_hanzo_settings()
+    config = BuildConfig.from_settings(config_settings or {})
+    # TODO: Maybe give an option to disable builtin features
+    config.add_builtin_features(settings)
+
+    project_name = to_snakecase(metadata.name)
+
+    sdist_directory = Path(sdist_directory)
+    sdist_file = sdist_directory / SDIST_FILENAME.format(
+        name=project_name, version=metadata.version
+    )
+
+    includes, excludes = settings.sdist.include, settings.sdist.exclude
+
+    # Use custom patterns if and only if provided, otherwise fall back to .gitignore
+    if includes or excludes:
+        matcher = GitignoreMatcher()
+        # since we're ignore-matching, we need to negate the includes.
+        matcher.add_patterns("!" + pat for pat in includes)
+        matcher.add_patterns(excludes)
+    else:
+        matcher = GitignoreMatcher.from_gitignore()
+
+    with tarfile.open(sdist_file, mode="w:gz") as sdist:
+        for file in matcher.match_files(Path.cwd()):
+            if matcher.ignored(file):
+                continue
+            sdist.add(str(file), arcname=file)
+
+    return sdist_file.name
 
 
 def get_requires_for_build_wheel(

--- a/src/hanzo/constants.py
+++ b/src/hanzo/constants.py
@@ -1,5 +1,6 @@
 METADATA_VERSION: str = "2.5"
 WHEEL_FILENAME = "{name}-{version}-{tag}.whl"
+SDIST_FILENAME = "{name}-{version}.tar.gz"
 
 # Default toolchain names for different languages
 DEFAULT_CC_TOOLCHAIN_NAME: str = "host"

--- a/src/hanzo/settings.py
+++ b/src/hanzo/settings.py
@@ -85,7 +85,8 @@ def ensure_scalar_setting(
 
 @dataclass
 class SdistSettings:
-    pass
+    include: list[str] = field(default_factory=list)
+    exclude: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/hanzo/utils.py
+++ b/src/hanzo/utils.py
@@ -21,8 +21,8 @@ class GitignorePattern(NamedTuple):
 
 
 class GitignoreMatcher:
-    def __init__(self, patterns: list[GitignorePattern]):
-        self.patterns: list[GitignorePattern] = patterns
+    def __init__(self, patterns: list[GitignorePattern] | None = None):
+        self.patterns: list[GitignorePattern] = patterns or []
 
     @classmethod
     def from_gitignore(cls, path: str | os.PathLike[str] | None = None) -> Self:
@@ -42,6 +42,19 @@ class GitignoreMatcher:
                 line = line[1:]
             patterns.append(GitignorePattern(line, negated))
         return cls(patterns)
+
+    def add_patterns(self, patterns: Iterable[str | GitignorePattern]) -> None:
+        for pattern in patterns:
+            self.add_pattern(pattern)
+
+    def add_pattern(self, pattern: str | GitignorePattern) -> None:
+        if isinstance(pattern, str):
+            negated = pattern.startswith("!")
+            if negated:
+                pattern = pattern[1:]
+            self.patterns.append(GitignorePattern(pattern, negated))
+        else:
+            self.patterns.append(pattern)
 
     def ignored(self, path: str | os.PathLike[str]) -> bool:
         """Check if a path is ignored based on the patterns in this .gitignore file."""


### PR DESCRIPTION
This is a rough first attempt, with support for verbose includes+excludes and gitignore matching (the default).

Adds pattern addition APIs to the `GitignoreMatcher`, and packs up the folder based on the file set discovered in the repo root.